### PR TITLE
OpenTelemetry Collector install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 </p>
 
 
-**[Online Boutique](https://microservices.demo.honeycomb.io)** is a cloud-native microservices demo application.
-Online Boutique consists of a 10-tier microservices application, writen in 5 different languages: Go, Java, .NET, Node, and Python.
-The application is a web-based e-commerce platform where users can browse items, add them to a cart, and purchase them.
+**[Online Boutique](https://microservices.demo.honeycomb.io)** is a cloud-native microservices demo application. Online
+Boutique consists of a 10-tier microservices application, writen in 5 different languages: Go, Java, .NET, Node, and
+Python. The application is a web-based e-commerce platform where users can browse items, add them to a cart, and
+purchase them.
 
-**[Honeycomb](https://honeycomb.io)** uses this application to demonstrate use of technologies like Kubernetes, gRPC, and OpenTelemetry. 
-This application works on any Kubernetes cluster. It’s **easy to deploy with little to no configuration**.
+**[Honeycomb](https://honeycomb.io)** uses this application to demonstrate use of technologies like Kubernetes, gRPC,
+and OpenTelemetry. This application works on any Kubernetes cluster. It’s **easy to deploy with little to no
+configuration**.
 
 ## Screenshots
 
@@ -18,9 +20,9 @@ This application works on any Kubernetes cluster. It’s **easy to deploy with l
 
 ## OpenTelemetry
 
-Online Boutique is instrumented using the [OpenTelemetry](https://opentelemetry.io) framework. 
-There are simple and advanced instrumentation techniques offered by OpenTelemetry that are leveraged in the application.
-Each service in the [src](./src) folder explains how OpenTelemetry was used with specific code examples.
+Online Boutique is instrumented using the [OpenTelemetry](https://opentelemetry.io) framework. There are simple and
+advanced instrumentation techniques offered by OpenTelemetry that are leveraged in the application. Each service in
+the [src](./src) folder explains how OpenTelemetry was used with specific code examples.
 
 ## Development
 
@@ -29,65 +31,59 @@ Each service in the [src](./src) folder explains how OpenTelemetry was used with
 - [Docker for Desktop](https://www.docker.com/products/docker-desktop).
 - kubectl (can be installed via `gcloud components install kubectl`)
 - [skaffold]( https://skaffold.dev/docs/install/), a tool that builds and deploys Docker images in bulk.
+- [Helm](https://helm.sh), a package manager for Kubernetes
 
 ### Install
 
 1. Launch a local Kubernetes cluster with one of the following tools:
 
-  - To launch **Minikube** (tested with Ubuntu Linux). Please, ensure that the
-    local Kubernetes cluster has at least:
+- To launch **Minikube** (tested with Ubuntu Linux). Please, ensure that the local Kubernetes cluster has at least:
     - 4 CPUs
     - 4.0 GiB memory
     - 32 GB disk space
+```shell
+minikube start --cpus=4 --memory 4096 --disk-size 32g
+```
 
-    ```shell
-    minikube start --cpus=4 --memory 4096 --disk-size 32g
-    ```
-
-  - To launch **Docker for Desktop** (tested with Mac/Windows). Go to Preferences:
+- To launch **Docker for Desktop** (tested with Mac/Windows). Go to Preferences:
     - choose “Enable Kubernetes”,
     - set CPUs to at least 3, and Memory to at least 6.0 GiB
     - on the "Disk" tab, set at least 32 GB disk space
 
-  - To launch a **Kind** cluster:
-
-    ```shell
-    kind create cluster
-    ```
-
 2. Run `kubectl get nodes` to verify you're connected to the respective control plane.
 
-3. Run `skaffold run` (first time will be slow, it can take ~20 minutes).
-   This will build and deploy the application. If you need to rebuild the images
-   automatically as you refactor the code, run `skaffold dev` command.
+3. Install the [OpenTelemetry Collector Helm chart](https://github.com/honeycombio/helm-charts/tree/main/charts/opentelemetry-collector) from Honeycomb.
+   Specify your Honeycomb API key when installing the Helm chart.
+```shell
+helm install opentelemetry-collector honeycomb/opentelemetry-collector \
+      --set honeycomb.apiKey=YOUR_API_KEY \
+      --values ./kubernetes-manifests/addional_resources/opentelemetry-collector-values.yaml
+```
 
-4. Run `kubectl get pods` to verify the Pods are ready and running.
+4. Run `skaffold run` (first time will be slow, it can take ~20 minutes). This will build and deploy the application. If
+   you need to rebuild the images automatically as you refactor the code, run `skaffold dev` command.
 
-5. Access the web frontend through your browser
-  - **Minikube** requires you to run a command to access the frontend service:
+5. Run `kubectl get pods` to verify the Pods are ready and running.
 
-    ```shell
-    minikube service frontend-external
-    ```
+6. Access the web frontend through your browser
 
-  - **Docker For Desktop** should automatically provide the frontend at http://localhost:80
+- **Minikube** requires you to run a command to access the frontend service:
+```shell
+minikube service frontend-external
+```
 
-  - **Kind** does not provision an IP address for the service.
-    You must run a port-forwarding process to access the frontend at http://localhost:8080:
+- **Docker For Desktop** should automatically provide the frontend at http://localhost:80
 
-    ```shell
-    kubectl port-forward deployment/frontend 8080:8080
-    ```
 
 ### Cleanup
 
 If you've deployed the application with `skaffold run` command, you can run
 `skaffold delete` to clean up the deployed resources.
 
-
 ## Architecture
 
-**Online Boutique** is composed of 10 microservices (plus a load generator) written in 5 different languages that talk to each other over gRPC.
+**Online Boutique** is composed of 10 microservices (plus a load generator) written in 5 different languages that talk
+to each other over gRPC.
 
 [![Architecture of microservices](./docs/img/architecture-diagram.png)](./docs/img/architecture-diagram.png)
 
@@ -111,37 +107,41 @@ Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb).
 
 - **[Kubernetes](https://kubernetes.io):**
   The app is designed to run on Kubernetes
-- **[gRPC](https://grpc.io):** Microservices use a high volume of gRPC calls to
-  communicate to each other.
-- **[OpenTelemetry](https://opentelemetry.io/) Tracing:** Most services are
-  instrumented using OpenTelemetry trace providers for gRPC/HTTP.
-- **[Skaffold](https://skaffold.dev):** Application
-  is deployed to Kubernetes with a single command using Skaffold.
-- **Synthetic Load Generation:** The application demo comes with a background
-  job that creates realistic usage patterns on the website using
+- **[gRPC](https://grpc.io):** Microservices use a high volume of gRPC calls to communicate to each other.
+- **[OpenTelemetry](https://opentelemetry.io/) Tracing:** Most services are instrumented using OpenTelemetry trace
+  providers for gRPC/HTTP.
+- **[Skaffold](https://skaffold.dev):** Application is deployed to Kubernetes with a single command using Skaffold.
+- **Synthetic Load Generation:** The application demo comes with a background job that creates realistic usage patterns
+  on the website using
   [Locust](https://locust.io/) load generator.
-
 
 ## History
 
-This project originated from the excellent Google Cloud Platform [Microservices Demo](https://github.com/GoogleCloudPlatform/microservices-demo).
-It was forked in 2021, before significant changes were performed.
-All application telemetry which was previously done with OpenCensus and Stackdriver, was moved to use [OpenTelemetry](https://opentelemetry.io) for application telemetry, with tracing export intended for an OpenTelemetry Collector.
-Additional instrumentation is leveraged throughout the application to show some basic and advanced capabilities of OpenTelemetry.
-This application is used as a demo platform for the Honeycomb team, and many changes were made to the application code so it will break in ways that make for a more compelling demonstration of the Honeycomb platform.
+This project originated from the excellent Google Cloud
+Platform [Microservices Demo](https://github.com/GoogleCloudPlatform/microservices-demo). It was forked in 2021, before
+significant changes were performed. All application telemetry which was previously done with OpenCensus and Stackdriver,
+was moved to use [OpenTelemetry](https://opentelemetry.io) for application telemetry, with tracing export intended for
+an OpenTelemetry Collector. Additional instrumentation is leveraged throughout the application to show some basic and
+advanced capabilities of OpenTelemetry. This application is used as a demo platform for the Honeycomb team, and many
+changes were made to the application code so it will break in ways that make for a more compelling demonstration of the
+Honeycomb platform.
 
 ## Application demo
-This application will exhibit a problem meant to be discovered with ease using the [Honeycomb](https://honeycomb.io) platform.
 
-The checkout service has a memory leak, cause by an internal cache store.
-This service has tight Kubernetes pod/container memory limits, so the leak will cause out of memory crashes, resulting in a pod restart after approximately 4 hours.
-Code in the checkout service will introduce additional delays in the form of SQL calls under `getDiscounts`.
-The number of SQL calls made will increase as the cache size increases, creating exponentially increasing latency.
-There is additional code in the frontend service, which will introduce a specific userid (20109) after the cache limit from checkout has reached a specific threshold.
-This results in a pattern where a single user from a pool of thousands, receiving a bad experience that continues to get worse.
+This application will exhibit a problem meant to be discovered with ease using the [Honeycomb](https://honeycomb.io)
+platform.
 
-When using Honeycomb BubbleUp, and combined with the Honeycomb SLO feature, understanding the single user from the high cardinality pool of thousands of user ids is easy to do.
-Honeycomb allows the user to ask novel questions from the data, to quickly understand the memory leak and cache problem in code.
+The checkout service has a memory leak, cause by an internal cache store. This service has tight Kubernetes
+pod/container memory limits, so the leak will cause out of memory crashes, resulting in a pod restart after
+approximately 4 hours. Code in the checkout service will introduce additional delays in the form of SQL calls
+under `getDiscounts`. The number of SQL calls made will increase as the cache size increases, creating exponentially
+increasing latency. There is additional code in the frontend service, which will introduce a specific userid (20109)
+after the cache limit from checkout has reached a specific threshold. This results in a pattern where a single user from
+a pool of thousands, receiving a bad experience that continues to get worse.
+
+When using Honeycomb BubbleUp, and combined with the Honeycomb SLO feature, understanding the single user from the high
+cardinality pool of thousands of user ids is easy to do. Honeycomb allows the user to ask novel questions from the data,
+to quickly understand the memory leak and cache problem in code.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ minikube start --cpus=4 --memory 4096 --disk-size 32g
 ```shell
 helm install opentelemetry-collector honeycomb/opentelemetry-collector \
       --set honeycomb.apiKey=YOUR_API_KEY \
-      --values ./kubernetes-manifests/addional_resources/opentelemetry-collector-values.yaml
+      --values ./kubernetes-manifests/additional_resources/opentelemetry-collector-values.yaml
 ```
 
 4. Run `skaffold run` (first time will be slow, it can take ~20 minutes). This will build and deploy the application. If

--- a/kubernetes-manifests/README.md
+++ b/kubernetes-manifests/README.md
@@ -4,3 +4,6 @@
 deployable to a cluster. They are meant to be used with `skaffold` command to
 insert the correct `image:` tags.
 
+The [additional_resources](./additional_resources) folder contains resources that should be installed using Helm or kubectl in order to run this application.
+See the main [readme](../README.md#install) for installation instructions. 
+

--- a/kubernetes-manifests/additional_resources/opentelemetry-collector-values.yaml
+++ b/kubernetes-manifests/additional_resources/opentelemetry-collector-values.yaml
@@ -1,0 +1,62 @@
+
+honeycomb:
+  # Specify either your apiKey, **OR** the  name of an existingSecret resource containing your Honeycomb API key
+  # apiKey: YOUR_API_KEY
+  # existingSecret: honeycomb-api-key
+
+  # Specify host URL to send all events to
+  apiHost: api.honeycomb.io:443
+  # Specify the name of the dataset to send data to
+  dataset: microservices-demo
+
+config:
+  processors:
+    k8s_tagger:
+      passthrough: false
+      auth_type: "kubeConfig"
+      extract:
+        metadata:
+          # extract the following well-known metadata fields
+          - podName
+          - podUID
+          - deployment
+          - cluster
+          - namespace
+          - node
+          - startTime
+  service:
+    extensions: [health_check]
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, batch, k8s_tagger]
+        exporters: [otlp]
+
+# disable ports that are not required
+ports:
+  jaeger-binary:
+    enabled: false
+  jaeger-compact:
+    enabled: false
+  jaeger-grpc:
+    enabled: false
+  jaeger-http:
+    enabled: false
+  zipkin:
+    enabled: false
+
+k8sProcessor:
+  rbac:
+    name: "microservices-tagger"
+    create: true
+
+serviceAccount:
+  create: true
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 2Gi
+  requests:
+    cpu: 200m
+    memory: 400Mi


### PR DESCRIPTION
Adds a sample Helm values file and readme instructions to installation instructions.

Full install instructions should now work end to end on a new Kubernetes cluster. 
