### PR TITLE
add marker before latency spike

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 
-**[Online Boutique](https://microservices.demo.honeycomb.io)** is a cloud-native microservices demo application. Online
+**[Online Boutique](https://microservices.honeydemo.io)** is a cloud-native microservices demo application. Online
 Boutique consists of a 10-tier microservices application, writen in 5 different languages: Go, Java, .NET, Node, and
 Python. The application is a web-based e-commerce platform where users can browse items, add them to a cart, and
 purchase them.
@@ -28,14 +28,14 @@ the [src](./src) folder explains how OpenTelemetry was used with specific code e
 
 ### Prerequisites
 
-- [Docker for Desktop](https://www.docker.com/products/docker-desktop).
-- kubectl (can be installed via `gcloud components install kubectl`)
-- [skaffold]( https://skaffold.dev/docs/install/), a tool that builds and deploys Docker images in bulk.
+- [Docker for Desktop](https://www.docker.com/products/docker-desktop)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl), a CLI to interact with Kubernetes
+- [skaffold]( https://skaffold.dev/docs/install/), a tool that builds and deploys Docker images in bulk
 - [Helm](https://helm.sh), a package manager for Kubernetes
 
 ### Install
 
-1. Launch a local Kubernetes cluster with one of the following tools:
+1. Launch a local Kubernetes cluster with one of the following options:
 
 - To launch **Minikube** (tested with Ubuntu Linux). Please, ensure that the local Kubernetes cluster has at least:
     - 4 CPUs
@@ -60,8 +60,8 @@ helm install opentelemetry-collector honeycomb/opentelemetry-collector \
       --values ./kubernetes-manifests/additional_resources/opentelemetry-collector-values.yaml
 ```
 
-4. Run `skaffold run` (first time will be slow, it can take ~20 minutes). This will build and deploy the application. If
-   you need to rebuild the images automatically as you refactor the code, run `skaffold dev` command.
+4. Run `skaffold run` (first time will be slow, it can take ~20 minutes). This will build and deploy the application. 
+   If you need to rebuild the images automatically as you refactor the code, run `skaffold dev` command.
 
 5. Run `kubectl get pods` to verify the Pods are ready and running.
 
@@ -77,13 +77,11 @@ minikube service frontend-external
 
 ### Cleanup
 
-If you've deployed the application with `skaffold run` command, you can run
-`skaffold delete` to clean up the deployed resources.
+If you've deployed the application with `skaffold run` command, you can run `skaffold delete` to clean up the deployed resources.
 
 ## Architecture
 
-**Online Boutique** is composed of 10 microservices (plus a load generator) written in 5 different languages that talk
-to each other over gRPC.
+**Online Boutique** is composed of 10 microservices (plus a load generator) written in 5 different languages that communicate with each other over gRPC.
 
 [![Architecture of microservices](./docs/img/architecture-diagram.png)](./docs/img/architecture-diagram.png)
 
@@ -146,4 +144,4 @@ to quickly understand the memory leak and cache problem in code.
 
 ---
 
-This is not an official Google or Honeycomb project.
+This is not an official Honeycomb or Google project.

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -52,22 +52,29 @@ spec:
             value: "checkoutservice:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
-          - name: FORCE_USER
-            value: "0"
-          - name: PERCENT_NORMAL
-            value: "50"
-          - name: CACHE_SIZE_THRESHOLD
-            value: "35000"
           - name: ENV_PLATFORM
             value: "aws"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: opentelemetry-collector:4317
           - name: POD_IP
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: opentelemetry-collector:4317
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: ip=$(POD_IP)
+          - name: PERCENT_NORMAL
+            value: "85"
+          - name: CACHE_MARKER_THRESHOLD
+            value: "30000"
+          - name: CACHE_USER_THRESHOLD
+            value: "35000"
+          - name: HONEYCOMB_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: honeycomb
+                key: api-key
+          - name: HONEYCOMB_DATASET
+            value: microservices-demo
           resources:
             requests:
               cpu: 100m

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -321,7 +321,7 @@ func getDiscounts(ctx context.Context, u string, cachesize int) string {
 	span.SetAttributes(userIDKey.String(u))
 	defer span.End()
 	rnd := rand.Float32()
-	if (u == "20109" && rnd < 0.5) || (rnd < 0.15) {
+	if (u == "20109" && rnd < 0.5) || (rnd < 0.25) {
 		return loadDiscountFromDatabase(ctx, cachesize)
 	} else {
 		return ""

--- a/src/frontend/cache.go
+++ b/src/frontend/cache.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type CacheTracker struct {
+	currentSize      int
+	userThreshold    int
+	markerThreshold  int
+	honeycombAPIKey  string
+	honeycombDataset string
+	log              logrus.FieldLogger
+	lock             sync.Mutex
+}
+
+func NewCacheTracker(userThreshold, markerThreshold int, apiKey, dataset string, log logrus.FieldLogger) *CacheTracker {
+	return &CacheTracker{
+		userThreshold:    userThreshold,
+		markerThreshold:  markerThreshold,
+		honeycombAPIKey:  apiKey,
+		honeycombDataset: dataset,
+		log:              log,
+	}
+}
+
+func (c *CacheTracker) GetSize() int {
+	return c.currentSize
+}
+
+func (c *CacheTracker) IsOverUserThreshold() bool {
+	return c.currentSize > c.userThreshold
+}
+
+func (c *CacheTracker) Track(ctx context.Context, fe *frontendServer) {
+	c.log.Infof("starting CacheTracker.Track()")
+	ticker := time.NewTicker(10 * time.Second)
+	go func() {
+		for range ticker.C {
+			resp, err := fe.getCacheSize(ctx)
+			if err != nil {
+				c.log.Error(errors.Wrap(err, "could not fetch cache size"))
+				return
+			}
+			c.updateSize(int(resp.CacheSize))
+			c.log.Debugf("current cache size is: %d", c.currentSize)
+		}
+	}()
+}
+
+func (c *CacheTracker) updateSize(newSize int) {
+	c.lock.Lock()
+
+	if newSize > c.markerThreshold && c.currentSize <= c.markerThreshold {
+		c.log.Debugf("marker threshold: %d has been reached, new size: %d", c.markerThreshold, newSize)
+		// Send a marker in a new Go routine
+		go c.createMarker()
+	}
+
+	c.currentSize = newSize
+	c.lock.Unlock()
+}
+
+func (c *CacheTracker) createMarker() {
+	if c.honeycombAPIKey == "" || c.honeycombDataset == "" {
+		// Do nothing
+		return
+	}
+
+	c.log.Debug("Creating Honeycomb marker...")
+
+	url := "https://api.honeycomb.io/1/markers/" + c.honeycombDataset
+	payload := []byte(`{"message":"Deploy C34E68A7","type":"deploy"}`)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		c.log.Error(errors.Wrap(err, "could not create request to generate marker"))
+		return
+	}
+	req.Header.Set("X-Honeycomb-Team", c.honeycombAPIKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		c.log.Error(errors.Wrap(err, "could not create Honeycomb marker"))
+	} else if resp.StatusCode != 200 {
+		c.log.Errorf("Invalid status code: %d, when creating Honeycomb marker", resp.StatusCode)
+	} else {
+		c.log.Debug("Honeycomb marker created.")
+	}
+
+}

--- a/src/frontend/middleware.go
+++ b/src/frontend/middleware.go
@@ -79,12 +79,12 @@ func ensureSessionID(next http.Handler) http.HandlerFunc {
 		userAgent := r.UserAgent()
 		rnd := rand.Intn(100) + 1
 
-		// DEMO: If the checkoutservice Cache size is greater than the CacheSizeThreshold (default 35000)
+		// DEMO: If the checkoutservice Cache size is greater than the CacheTrack.userThreshold (default 35000)
 		// AND the request is from the load generator (useragent contains python)
 		// AND rnd > PercentNormal
 		// Then we will use a session id of 20109 to emphasize a problematic user
 		// sessionID will be referenced as userid in OpenTelemetry data
-		if CurrentCacheSize > CacheSizeThreshold && strings.Contains(userAgent, "python") && rnd > PercentNormal {
+		if CacheTrack.IsOverUserThreshold() && strings.Contains(userAgent, "python") && rnd > PercentNormal {
 			// Use the static sessionID "20109"
 			sessionID = "20109"
 			http.SetCookie(w, &http.Cookie{

--- a/src/frontend/rpc.go
+++ b/src/frontend/rpc.go
@@ -114,6 +114,6 @@ func (fe *frontendServer) getAd(ctx context.Context, ctxKeys []string) ([]*pb.Ad
 func (fe *frontendServer) getCacheSize(ctx context.Context) (*pb.CacheSizeResponse, error) {
 
 	resp, err := pb.NewCheckoutServiceClient(fe.checkoutSvcConn).GetCacheSize(ctx, &pb.Empty{})
-	return resp, errors.Wrap(err, "failed to get cache size")
+	return resp, errors.Wrap(err, "failed to get CacheTracker size")
 
 }


### PR DESCRIPTION
refactors how checkout cache is tracked from frontend

adds a new marker in Honeycomb when cache maker threshold is reached (default 30000)