### PR TITLE
add a url to the marker and sort imports

### DIFF
--- a/src/frontend/cache.go
+++ b/src/frontend/cache.go
@@ -3,12 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type CacheTracker struct {
@@ -87,7 +88,7 @@ func (c *CacheTracker) createMarker() {
 	c.log.Debug("Creating Honeycomb marker...")
 
 	url := "https://api.honeycomb.io/1/markers/" + c.honeycombDataset
-	payload := []byte(`{"message":"Deploy C34E68A7","type":"deploy"}`)
+	payload := []byte(`{"message":"Deploy C34E68A7", "url":"https://github.com/honeycombio/microservices-demo/commit/36bbbc36afebf145a992a7446554fb5371be149f", "type":"deploy"}`)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
 	if err != nil {
 		c.log.Error(errors.Wrap(err, "could not create request to generate marker"))


### PR DESCRIPTION
Fixes # .
NA

Change summary:
- Sorts some imports 
- Adds a URL to [this](https://github.com/honeycombio/microservices-demo/commit/36bbbc36afebf145a992a7446554fb5371be149f) Github commit when creating deploy marker


Remaining issues / concerns:
NA
