### PR TITLE
specify scheme as part of frontend addr

### DIFF
--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -22,9 +22,9 @@ spec:
         image: loadgenerator
         env:
         - name: FRONTEND_ADDR
-          value: "frontend:80"
+          value: http://frontend
         - name: USERS
-          value: "10"
+          value: "5"
         resources:
           requests:
             cpu: 300m

--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -11,11 +11,11 @@ fi
 set -x
 
 # if one request to the frontend fails, then exit
-STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://${FRONTEND_ADDR})
+STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" "${FRONTEND_ADDR}")
 if test $STATUSCODE -ne 200; then
     echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
     exit 1
 fi
 
 # else, run loadgen
-locust --host="http://${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1
+locust --host="${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1


### PR DESCRIPTION
Setup load generator to have http/https scheme specified as part of URL.  Also lowered user count from 10 to 5.

Allows for more flexibility in how load generator is used. A separate (private) load of 5 users will be setup going via the externally accessible URL which is outside the scope of this repo.