### PR TITLE
Add environment wide deploy markers

### DIFF
--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -74,7 +74,7 @@ spec:
                 name: honeycomb-opentelemetry-collector
                 key: api-key
           - name: HONEYCOMB_DATASET
-            value: microservices-demo
+            value: __all__
           resources:
             requests:
               cpu: 100m

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,39 +1,72 @@
-apiVersion: skaffold/v1beta2
+apiVersion: skaffold/v2beta29
 kind: Config
 build:
   artifacts:
-  # image tags are relative; to specify an image repo (e.g. GCR), you
-  # must provide a "default repo" using one of the methods described
-  # here:
-  # https://skaffold.dev/docs/concepts/#image-repository-handling
+    # image tags are relative; to specify an image repo (e.g. GCR), you
+    # must provide a "default repo" using one of the methods described
+    # here:
+    # https://skaffold.dev/docs/concepts/#image-repository-handling
     - image: adservice
       context: src/adservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: cartservice
       context: src/cartservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: checkoutservice
       context: src/checkoutservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: currencyservice
       context: src/currencyservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: emailservice
       context: src/emailservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: frontend
       context: src/frontend
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: loadgenerator
       context: src/loadgenerator
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: paymentservice
       context: src/paymentservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: productcatalogservice
       context: src/productcatalogservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: recommendationservice
       context: src/recommendationservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
     - image: shippingservice
       context: src/shippingservice
+      docker:
+        cliFlags:
+          - --platform=linux/x86_64
   tagPolicy:
     gitCommit: {}
   local:
-    useBuildkit: false
+    # useBuildkit: false
+    useDockerCLI: true
 deploy:
   kubectl:
     manifests:
       - ./kubernetes-manifests/**.yaml
-

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -2,14 +2,14 @@ FROM openjdk:11-slim as builder
 
 WORKDIR /app
 
-COPY ["build.gradle", "gradlew", "./"]
-COPY gradle gradle
-RUN chmod +x gradlew
-RUN ./gradlew downloadRepos
+# COPY ["build.gradle", "gradlew", "./"]
+# COPY gradle gradle
+# RUN chmod +x gradlew
+# RUN ./gradlew downloadRepos
 
 COPY . .
 RUN chmod +x gradlew
-RUN ./gradlew installDist
+RUN ./gradlew installDist --console=plain
 
 FROM openjdk:11-slim
 

--- a/src/frontend/cache.go
+++ b/src/frontend/cache.go
@@ -88,7 +88,7 @@ func (c *CacheTracker) createMarker() {
 	c.log.Debug("Creating Honeycomb marker...")
 
 	url := "https://api.honeycomb.io/1/markers/" + c.honeycombDataset
-	payload := []byte(`{"message":"Deploy 5645075", "url":"https://github.com/honeycombio/microservices-demo/commit/5645075", "type":"deploy"}`)
+	payload := []byte(`{"message":"Deploy: 5645075 | Service: checkout", "url":"https://github.com/honeycombio/microservices-demo/commit/5645075", "type":"deploy"}`)
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
 	if err != nil {
 		c.log.Error(errors.Wrap(err, "could not create request to generate marker"))


### PR DESCRIPTION
This changes the dataset that the frontend code publishes markers to from `microservices-demo` to `__all__`. 

Because we're sending data to an E&S team for Play V2, having the frontend be the only dataset with deploy markers is confusing and hard to understand for our script. Adding environment wide deploy markers means that no matter which dataset the user is on, they'll be able to see when the deploy happened.


Fixes # .

https://app.asana.com/0/1202400451269267/1202715843865043/f

Remaining issues / concerns:

We could probably update the name of the deploy to be more specific about which service is actually 'deployed' (I think it's supposed to be the 'checkout' service?)

How can we make that dataset name a bit more configurable?


Branched off of #49 -- this isn't really ready to merge to the main branch
