### PR TITLE
fix: loadgenerator fails when frontend is not available - issue #80

### DIFF
--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 trap "exit" TERM
 
 if [[ -z "${FRONTEND_ADDR}" ]]; then
@@ -8,14 +7,12 @@ if [[ -z "${FRONTEND_ADDR}" ]]; then
     exit 1
 fi
 
-set -x
+# set -x
 
-# Keep trying until the frontend is reachable
+# if one request to the frontend fails, then exit
 while true; do
     STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" "${FRONTEND_ADDR}")
-    if test $STATUSCODE -eq 200; then
-        break
-    else
+    if test $STATUSCODE -ne 200; then
         echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
         sleep 1
     fi

--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -10,12 +10,16 @@ fi
 
 set -x
 
-# if one request to the frontend fails, then exit
-STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" "${FRONTEND_ADDR}")
-if test $STATUSCODE -ne 200; then
-    echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
-    exit 1
-fi
+# Keep trying until the frontend is reachable
+while true; do
+    STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" "${FRONTEND_ADDR}")
+    if test $STATUSCODE -eq 200; then
+        break
+    else
+        echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
+        sleep 1
+    fi
+done
 
 # else, run loadgen
 locust --host="${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1


### PR DESCRIPTION
Fixes #80 

Change summary:
- changed loadgen.sh which will check and loop to check for the availability of frontend. Loop time is every 1 second.

Remaining issues / concerns:
- the container will keep looping until it can reach frontend.