### PR TITLE
fix: Update currencyservice.yaml

### DIFF
--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -26,12 +26,12 @@ spec:
           value: grpc
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: http://opentelemetry-collector:4317
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: ip=$(POD_IP)
         - name: POD_IP
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: ip=$(POD_IP)
         - name: OTEL_SERVICE_NAME
           value: currency
         # readinessProbe:


### PR DESCRIPTION
POD_IP must come before OTEL_RESOURCE_ATTRIBUTES where it is being used as variable.

Change summary:
- OTEL_RESOURCE_ATTRIBUTE is using $(POD_IP), but in order for it to use, POD_IP must be defined before it. The fix fixes the order of environment variables so that the value of POD_IP will be properly applied.

