### PR TITLE
adding docker build to build multi-platform support

### DIFF
--- a/.github/workflows/checkoutservice.yml
+++ b/.github/workflows/checkoutservice.yml
@@ -49,6 +49,6 @@ jobs:
           REPOSITORY: microservices-demo/checkoutservice
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -t $REGISTRY/$REPOSITORY:latest .
+          docker buildx build --platform linux/amd64,linux/arm64 -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -t $REGISTRY/$REPOSITORY:latest .
           docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REPOSITORY:latest

--- a/src/checkoutservice/README.md
+++ b/src/checkoutservice/README.md
@@ -74,6 +74,7 @@ func initOtelTracing(ctx context.Context, log logrus.FieldLogger) *sdktrace.Trac
 ```
 
 The [logrus](https://github.com/sirupsen/logrus) package is added with OtelHook which generates Otel Logs.
+
 ```go
 // OtelHook is a logrus hook that sends logs to OpenTelemetry
 type OtelHook struct{}
@@ -128,8 +129,10 @@ func init() {
 You should call `TraceProvider.shutdown()` when your service is shutdown to ensure all spans are exported.
 This service makes that call as part of a deferred function in `main`
 ```
-	// Initialize OpenTelemetry Tracing
+	// Initialize OpenTelemetry Log and Tracing
 	ctx := context.Background()
+	lp := initOtelLogging(ctx)
+	defer func() { _ = lp.Shutdown(ctx) }()
 	tp := initOtelTracing(ctx, log)
 	defer func() { _ = tp.Shutdown(ctx) }()
 ```

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -186,7 +186,7 @@ func initOtelTracing(ctx context.Context, log logrus.FieldLogger) *sdktrace.Trac
 }
 
 func main() {
-	// Initialize OpenTelemetry Tracing
+	// Initialize OpenTelemetry Log and Tracing
 	ctx := context.Background()
 	lp := initOtelLogging(ctx)
 	defer func() { _ = lp.Shutdown(ctx) }()


### PR DESCRIPTION
building the image and pushing via git action workflow seems to have incorrect (or invalid)
binary format of the container image, suggesting that building the docker image via multi-platform might be the solution to this issue.