### PR TITLE
changed the runner to be in arm64 architecture.

### DIFF
--- a/.github/workflows/adservice.yml
+++ b/.github/workflows/adservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-adservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/cartservice.yml
+++ b/.github/workflows/cartservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-cartservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/checkoutservice.yml
+++ b/.github/workflows/checkoutservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-checkoutservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/currencyservice.yml
+++ b/.github/workflows/currencyservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-currencyservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/emailservice.yml
+++ b/.github/workflows/emailservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-emailservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/loadgenerator.yml
+++ b/.github/workflows/loadgenerator.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-loadgenerator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/paymentservice.yml
+++ b/.github/workflows/paymentservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-paymentservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/productcatalogservice.yml
+++ b/.github/workflows/productcatalogservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-productcatalogservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/recommendationservice.yml
+++ b/.github/workflows/recommendationservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-recommendationservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/shippingservice.yml
+++ b/.github/workflows/shippingservice.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-and-push-shippingservice:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION


Change summary:
- Previously, the github action was producing incorrect binary based on amd64 architecture and pushed into ECR.
- This would cause the image to crash during deployment, as ECS that we're running for msdemo is based on arm64
- Changing the runner for github action workflow will build the proper architecture image, and should work without this errors.

Big thanks to @puckpuck !

