### PR TITLE
changes to the cache logic producing build id

### DIFF
--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -47,14 +47,14 @@ spec:
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: ip=$(POD_IP)
           - name: CACHE_USER_THRESHOLD
-            value: "35000"
+            value: "25000"
           resources:
             requests:
               cpu: 100m
-              memory: 40Mi
+              memory: 39Mi
             limits:
               cpu: 200m
-              memory: 40Mi
+              memory: 39Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -65,9 +65,9 @@ spec:
           - name: PERCENT_NORMAL
             value: "85"
           - name: CACHE_MARKER_THRESHOLD
-            value: "26000"
+            value: "1000"
           - name: CACHE_USER_THRESHOLD
-            value: "35000"
+            value: "25000"
           - name: HONEYCOMB_API_KEY
             valueFrom:
               secretKeyRef:

--- a/src/frontend/cache.go
+++ b/src/frontend/cache.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
@@ -77,12 +78,12 @@ func (c *CacheTracker) updateSize(newSize int) {
 
 func (c *CacheTracker) createMarker() {
 
-	c.createMarkerHoneycomb()
 	MockBuildId = randomHex(4) // update build id
+	c.createMarkerHoneycomb(MockBuildId)
 
 }
 
-func (c *CacheTracker) createMarkerHoneycomb() {
+func (c *CacheTracker) createMarkerHoneycomb(buildId string) {
 	if c.honeycombAPIKey == "" {
 		// Do nothing
 		return
@@ -90,7 +91,7 @@ func (c *CacheTracker) createMarkerHoneycomb() {
 	c.log.Debug("Creating Honeycomb marker...")
 
 	url := "https://api.honeycomb.io/1/markers/__all__"
-	payload := []byte(`{"message":"Deploy 5645075", "url":"https://github.com/honeycombio/microservices-demo/commit/5645075", "type":"deploy"}`)
+	payload := []byte(fmt.Sprintf(`{"message":"Deploy %s", "url":"https://github.com/honeycombio/microservices-demo/commit/5645075", "type":"deploy"}`, buildId))
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
 	if err != nil {
 		c.log.Error(errors.Wrap(err, "could not create request to generate marker"))


### PR DESCRIPTION
modified the marker to use build ID on its name, rather than the commit id.

